### PR TITLE
fix: restore CI after Dependabot bumped sap/btp and terracurl providers

### DIFF
--- a/.github/actions/create-sap-btp-kyma/main.tf
+++ b/.github/actions/create-sap-btp-kyma/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.19.0"
+      version = "~> 1.24.0"
     }
     terracurl = {
       source  = "devops-rob/terracurl"
-      version = "~> 2.2.0"
+      version = "~> 2.3.0"
     }
   }
 }
@@ -37,4 +37,3 @@ module "kyma" {
 output "subaccount_id" {
   value = module.kyma.subaccount_id
 }
-


### PR DESCRIPTION
Automated fix for CI failure introduced by Dependabot merging PR #153 (sap/btp 1.23.1 → 1.24.0) and PR #143 (terracurl 2.2 → 2.3).

## Problem

`.github/actions/create-sap-btp-kyma/main.tf` declares its own provider version constraints AND references the root module via `git::https://github.com/kyma-project/terraform-btp-kyma-environment.git?ref=main`. Terraform intersects both constraint sets during `init`:

- action: `sap/btp ~> 1.19.0` + root module: `sap/btp ~> 1.24.0` → no valid version
- action: `terracurl ~> 2.2.0` + root module: `terracurl ~> 2.3.0` → no valid version

## Fix

Updated `.github/actions/create-sap-btp-kyma/main.tf` provider constraints to match `provider.tf`:
- `sap/btp`: `~> 1.19.0` → `~> 1.24.0`
- `devops-rob/terracurl`: `~> 2.2.0` → `~> 2.3.0`